### PR TITLE
исправление ошибки в тесте

### DIFF
--- a/src/the_tale/the_tale/game/actions/tests/test_battle.py
+++ b/src/the_tale/the_tale/game/actions/tests/test_battle.py
@@ -447,6 +447,7 @@ class TryCompanionBlockTests(TestsBase):
         self.assertTrue(self.hero.companion.is_dead)
         self.assertEqual(reset_accessors_cache.call_count, 1)
 
+
     @mock.patch('the_tale.game.companions.objects.Companion.defend_in_battle_probability', 1.0)
     @mock.patch('the_tale.game.heroes.objects.Hero.companion_damage_probability', 1.0)
     @mock.patch('the_tale.game.heroes.messages.JournalContainer.MESSAGES_LOG_LENGTH', 10000)

--- a/src/the_tale/the_tale/game/actions/tests/test_battle.py
+++ b/src/the_tale/the_tale/game/actions/tests/test_battle.py
@@ -447,8 +447,7 @@ class TryCompanionBlockTests(TestsBase):
         self.assertTrue(self.hero.companion.is_dead)
         self.assertEqual(reset_accessors_cache.call_count, 1)
 
-
-    @mock.patch('the_tale.game.balance.formulas.companions_defend_in_battle_probability', mock.Mock(return_value=1.0))
+    @mock.patch('the_tale.game.companions.objects.Companion.defend_in_battle_probability', 1.0)
     @mock.patch('the_tale.game.heroes.objects.Hero.companion_damage_probability', 1.0)
     @mock.patch('the_tale.game.heroes.messages.JournalContainer.MESSAGES_LOG_LENGTH', 10000)
     @mock.patch('the_tale.game.heroes.objects.Hero.can_companion_broke_to_spare_parts', lambda self: True)


### PR DESCRIPTION
ошибка приводила к рандомным провалам теста, по той причине, что  замоканое 
the_tale.game.balance.formulas.companions_defend_in_battle_probability
далее в методе: 
the_tale.game.companions.objects.Companion.defend_in_battle_probability 
подвергалось незначительной корректировке (с 1.0 примерно до 0.9) 

пример фэйла:
======================================================================
FAIL: test_killed_on_block__has_spare_parts (the_tale.game.actions.tests.test_battle.TryCompanionBlockTe
sts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.5/unittest/mock.py", line 1157, in patched
    return func(*args, **keywargs)
  File "/mnt/repos/the-tale/src/the_tale/the_tale/game/actions/tests/test_battle.py", line 468, in test_
killed_on_block__has_spare_parts
    self.assertTrue(battle.try_companion_block(attacker=actor_2, defender=actor_1, messenger=self.hero))

AssertionError: False is not true