### PR TITLE
apt: state=present вместо installed в тасках ansible

### DIFF
--- a/deploy/provisioning/tasks/dev_environment.yml
+++ b/deploy/provisioning/tasks/dev_environment.yml
@@ -6,7 +6,7 @@
 
   tasks:
 
-    - apt: name={{item}} state=installed
+    - apt: name={{item}} state=present
       with_items:
         - node-less
         - unzip

--- a/deploy/provisioning/tasks/postfix.yml
+++ b/deploy/provisioning/tasks/postfix.yml
@@ -6,7 +6,7 @@
   tasks:
 
     - name: Ensure postfix is installed
-      apt: name=postfix state=installed
+      apt: name=postfix state=present
 
     - name: install configs
       template:


### PR DESCRIPTION
Раньше можно было писать 'installed', теперь совсем не работает. Немного деталей обсудили на форуме:
https://the-tale.org/forum/threads/8025?page=5#m257442
https://the-tale.org/forum/threads/8025?page=6#m257785

Если совсем коротко, то вот: https://github.com/ansible/ansible/commit/4ec8599c3801e4737fddcca9b1d034885404a9c1