### PR TITLE
Добавлено пролонгирование времени жизни сессии приложений

### DIFF
--- a/src/the_tale/the_tale/accounts/third_party/conf.py
+++ b/src/the_tale/the_tale/accounts/third_party/conf.py
@@ -8,5 +8,6 @@ settings = utils_app_settings.app_settings('THIRD_PARTY',
                                            ACCESS_TOKEN_SESSION_KEY='third-party-access-token',
                                            ACCESS_TOKEN_CACHE_KEY='tpat-token-%s',
                                            ACCESS_TOKEN_CACHE_TIMEOUT=10 * 60,
+                                           SESSION_EXPIRE='session-expire',
                                            UNPROCESSED_ACCESS_TOKEN_LIVE_TIME=10  # minutes
                                            )

--- a/src/the_tale/the_tale/accounts/third_party/middleware.py
+++ b/src/the_tale/the_tale/accounts/third_party/middleware.py
@@ -28,6 +28,11 @@ class ThirdPartyMiddleware(object):
 
         access_token_uid = request.session[conf.settings.ACCESS_TOKEN_SESSION_KEY]
 
+        session_expire = accounts_logic.get_session_expire_at_timestamp(request)
+
+        # put new info to session to prolong its life
+        request.session[conf.settings.SESSION_EXPIRE] = session_expire
+
         cache_key = conf.settings.ACCESS_TOKEN_CACHE_KEY % access_token_uid
         cached_data = utils_cache.get(cache_key)
 
@@ -38,6 +43,8 @@ class ThirdPartyMiddleware(object):
                 if request.user.is_authenticated:
                     accounts_logic.logout_user(request)
                     request.session[conf.settings.ACCESS_TOKEN_SESSION_KEY] = access_token_uid
+                    request.session[conf.settings.SESSION_EXPIRE] = session_expire
+
                     return HANDLE_THIRD_PARTY_RESULT.ACCESS_TOKEN_REJECTED__LOGOUT
                 else:
                     return HANDLE_THIRD_PARTY_RESULT.ACCESS_TOKEN_REJECTED
@@ -53,6 +60,7 @@ class ThirdPartyMiddleware(object):
                 accounts_logic.logout_user(request)
                 # resave token, since it will be removed on logout
                 request.session[conf.settings.ACCESS_TOKEN_SESSION_KEY] = access_token_uid
+                request.session[conf.settings.SESSION_EXPIRE] = session_expire
 
             return HANDLE_THIRD_PARTY_RESULT.ACCESS_TOKEN_NOT_ACCEPTED_YET
 
@@ -62,6 +70,7 @@ class ThirdPartyMiddleware(object):
 
             # resave token, since it will be removed on login
             request.session[conf.settings.ACCESS_TOKEN_SESSION_KEY] = access_token_uid
+            request.session[conf.settings.SESSION_EXPIRE] = session_expire
 
             return HANDLE_THIRD_PARTY_RESULT.ACCESS_TOKEN_ACCEPTED__USER_LOGED_IN
 

--- a/src/the_tale/the_tale/accounts/third_party/views.py
+++ b/src/the_tale/the_tale/accounts/third_party/views.py
@@ -107,7 +107,7 @@ class TokensResource(utils_resources.Resource):
             data['account_id'] = None
             data['account_name'] = None
 
-        data['session_expire_at'] = accounts_logic.get_session_expire_at_timestamp(self.request)
+        data['session_expire_at'] = self.request.session[conf.settings.SESSION_EXPIRE]
 
         if conf.settings.ACCESS_TOKEN_SESSION_KEY not in self.request.session:
             data['state'] = relations.AUTHORISATION_STATE.NOT_REQUESTED.value


### PR DESCRIPTION
* Исправляет баг #2666
* В third_party/middleware добавлен код записи новых данных в сессию, что бы происходило обновление ее жизни в хранилище сессий.
* На мой взгляд, данный метод не решает "суть" проблемы - потерю доступа, в случае потери сессии на сервере - но позволяет продлевать жизнь существующей сессии доступа, при ее использовании.