### PR TITLE
Добавлен возврат access_token_uid и его использование для восстановления сессии

### DIFF
--- a/src/the_tale/the_tale/accounts/third_party/conf.py
+++ b/src/the_tale/the_tale/accounts/third_party/conf.py
@@ -5,6 +5,7 @@ smart_imports.all()
 
 
 settings = utils_app_settings.app_settings('THIRD_PARTY',
+                                           ACCESS_TOKEN_HEADER_KEY='third-party-token',
                                            ACCESS_TOKEN_SESSION_KEY='third-party-access-token',
                                            ACCESS_TOKEN_CACHE_KEY='tpat-token-%s',
                                            ACCESS_TOKEN_CACHE_TIMEOUT=10 * 60,

--- a/src/the_tale/the_tale/accounts/third_party/middleware.py
+++ b/src/the_tale/the_tale/accounts/third_party/middleware.py
@@ -23,10 +23,12 @@ class ThirdPartyMiddleware(object):
 
     def handle_third_party(self, request):
 
-        if conf.settings.ACCESS_TOKEN_SESSION_KEY not in request.session:
+        if conf.settings.ACCESS_TOKEN_HEADER_KEY in request.headers:
+            access_token_uid = request.headers.get(conf.settings.ACCESS_TOKEN_HEADER_KEY)
+        elif conf.settings.ACCESS_TOKEN_SESSION_KEY in request.session:
+            access_token_uid = request.session[conf.settings.ACCESS_TOKEN_SESSION_KEY]
+        else:
             return HANDLE_THIRD_PARTY_RESULT.NO_ACCESS_TOKEN
-
-        access_token_uid = request.session[conf.settings.ACCESS_TOKEN_SESSION_KEY]
 
         cache_key = conf.settings.ACCESS_TOKEN_CACHE_KEY % access_token_uid
         cached_data = utils_cache.get(cache_key)


### PR DESCRIPTION
* Более комплексное решение проблемы: #2666 чем PR: #2667 
* Добавляет новые версии (1.1) для методов request-authorisation и api_authorisation_state. Методы начинают возвращать access_token_uid.
* В third_party/middleware добавлена логика получения access_token_uid из заголовка запроса и использование его для восстановления сессии.
