### PR TITLE
Сокрытие инфо игрока и его героя при бане + тесты

### DIFF
--- a/src/the_tale/the_tale/accounts/prototypes.py
+++ b/src/the_tale/the_tale/accounts/prototypes.py
@@ -57,7 +57,9 @@ class AccountPrototype(utils_prototypes.BasePrototype):
         return self.id in conf.settings.MODERATORS_IDS
 
     @property
-    def description_html(self): return bbcode_renderers.default.render(self.description)
+    def description_html(self):
+        if not self.is_ban_any:
+            return bbcode_renderers.default.render(self.description)
 
     @utils_decorators.lazy_property
     def permanent_purchases(self):

--- a/src/the_tale/the_tale/accounts/prototypes.py
+++ b/src/the_tale/the_tale/accounts/prototypes.py
@@ -60,6 +60,7 @@ class AccountPrototype(utils_prototypes.BasePrototype):
     def description_html(self):
         if not self.is_ban_any:
             return bbcode_renderers.default.render(self.description)
+        return bbcode_renderers.default.render('')
 
     @utils_decorators.lazy_property
     def permanent_purchases(self):

--- a/src/the_tale/the_tale/accounts/tests/test_account_prototype.py
+++ b/src/the_tale/the_tale/accounts/tests/test_account_prototype.py
@@ -1,6 +1,6 @@
 
 import smart_imports
-
+from accounts import prototypes 
 smart_imports.all()
 
 
@@ -166,6 +166,19 @@ class AccountPrototypeTests(utils_testcase.TestCase, personal_messages_helpers.M
         self.account._model.ban_forum_end_at = datetime.datetime.now()
         self.assertFalse(self.account.is_ban_forum)
 
+    def test_banned_acc_description(self):
+        self.account.description = "bla-bla"
+        self.assertFalse(self.account.is_ban_game)
+        with mock.patch('the_tale.accounts.prototypes.AccountPrototype.cmd_update_hero') as cmd_update_hero:
+            self.account.ban_game(2)
+
+        self.assertEqual(cmd_update_hero.call_count, 1)
+        self.assertTrue(self.account.is_ban_game)
+
+        self.account.reload()
+
+        self.assertEqual(self.account.description_html, '')
+
     def test_bank_account__not_created(self):
         bank_account = self.account.bank_account
 
@@ -289,3 +302,6 @@ class AccountPrototypeBanTests(utils_testcase.TestCase):
         self.assertFalse(self.account.is_ban_game)
 
         self.assertTrue(self.account._model.ban_forum_end_at < datetime.datetime.now())
+
+
+

--- a/src/the_tale/the_tale/accounts/tests/test_account_prototype.py
+++ b/src/the_tale/the_tale/accounts/tests/test_account_prototype.py
@@ -1,6 +1,6 @@
 
 import smart_imports
-from accounts import prototypes 
+
 smart_imports.all()
 
 
@@ -166,17 +166,16 @@ class AccountPrototypeTests(utils_testcase.TestCase, personal_messages_helpers.M
         self.account._model.ban_forum_end_at = datetime.datetime.now()
         self.assertFalse(self.account.is_ban_forum)
 
-    def test_banned_acc_description(self):
+    def test_account_description(self):
+        self.account.description = "bla-bla"
+        self.assertEqual(self.account.description_html, "bla-bla")
+
+    def test_banned_account_description(self):
         self.account.description = "bla-bla"
         self.assertFalse(self.account.is_ban_game)
-        with mock.patch('the_tale.accounts.prototypes.AccountPrototype.cmd_update_hero') as cmd_update_hero:
-            self.account.ban_game(2)
-
-        self.assertEqual(cmd_update_hero.call_count, 1)
+        self.account.ban_game(days=1)
         self.assertTrue(self.account.is_ban_game)
-
-        self.account.reload()
-
+        
         self.assertEqual(self.account.description_html, '')
 
     def test_bank_account__not_created(self):

--- a/src/the_tale/the_tale/game/heroes/jinja2/hero_about.html
+++ b/src/the_tale/the_tale/game/heroes/jinja2/hero_about.html
@@ -6,7 +6,7 @@
 
   {% set description = value('the_tale.game.heroes.logic').get_hero_description(master_account.id) %}
 
-  {% if description %}
+  {% if description and not master_account.is_ban_any%}
 
   {{description|bb}}
 

--- a/src/the_tale/the_tale/game/heroes/jinja2/hero_about.html
+++ b/src/the_tale/the_tale/game/heroes/jinja2/hero_about.html
@@ -12,7 +12,9 @@
 
   {% else %}
 
-  <p>Хранитель пока ничего не рассказал о герое.</p>
+  <p class="test-no-hero-description-message">
+    Хранитель пока ничего не рассказал о герое.
+  </p>
 
   {% if is_owner %}
   <p class="alert alert-info">

--- a/src/the_tale/the_tale/game/heroes/logic.py
+++ b/src/the_tale/the_tale/game/heroes/logic.py
@@ -361,10 +361,13 @@ def get_heroes_to_accounts_map(heroes_ids):
 
 
 def get_hero_description(hero_id):
+    account = accounts_prototypes.AccountPrototype.get_by_id(hero_id)
+    if account.is_ban_any:
+        return ''
     try:
         return models.HeroDescription.objects.get(hero_id=hero_id).text
     except models.HeroDescription.DoesNotExist:
-        return ''
+                return ''
 
 
 def set_hero_description(hero_id, text):

--- a/src/the_tale/the_tale/game/heroes/logic.py
+++ b/src/the_tale/the_tale/game/heroes/logic.py
@@ -361,9 +361,6 @@ def get_heroes_to_accounts_map(heroes_ids):
 
 
 def get_hero_description(hero_id):
-    account = accounts_prototypes.AccountPrototype.get_by_id(hero_id)
-    if account.is_ban_any:
-        return ''
     try:
         return models.HeroDescription.objects.get(hero_id=hero_id).text
     except models.HeroDescription.DoesNotExist:

--- a/src/the_tale/the_tale/game/heroes/logic.py
+++ b/src/the_tale/the_tale/game/heroes/logic.py
@@ -367,7 +367,7 @@ def get_hero_description(hero_id):
     try:
         return models.HeroDescription.objects.get(hero_id=hero_id).text
     except models.HeroDescription.DoesNotExist:
-                return ''
+        return ''
 
 
 def set_hero_description(hero_id, text):

--- a/src/the_tale/the_tale/game/heroes/tests/test_logic.py
+++ b/src/the_tale/the_tale/game/heroes/tests/test_logic.py
@@ -20,6 +20,15 @@ class HeroDescriptionTests(utils_testcase.TestCase):
     def test_no_description(self):
         self.assertEqual(logic.get_hero_description(self.hero.id), '')
 
+    def test_banned_acc_hero_description(self):
+        logic.set_hero_description(self.hero.id, 'bla-bla')
+        self.assertFalse(account.is_ban_game)
+        with mock.patch('the_tale.game.workers.supervisor.Worker.cmd_sync_hero_required') as cmd_sync_hero_required:
+            account.ban_game(days=1)
+        self.assertEqual(cmd_sync_hero_required.call_count, 1)
+        self.assertTrue(account.is_ban_game)
+        self.assertEqual(logic.get_hero_description(self.hero.id), '')
+
     def test_has_description(self):
         logic.set_hero_description(self.hero.id, 'bla-bla')
         self.assertEqual(logic.get_hero_description(self.hero.id), 'bla-bla')

--- a/src/the_tale/the_tale/game/heroes/tests/test_logic.py
+++ b/src/the_tale/the_tale/game/heroes/tests/test_logic.py
@@ -30,7 +30,8 @@ class HeroDescriptionTests(utils_testcase.TestCase):
         self.assertFalse(account.is_ban_game)
         account.ban_game(days=1)
         self.assertTrue(account.is_ban_game)
-        self.assertEqual(logic.get_hero_description(self.hero.id), '')
+        self.check_html_ok(self.request_html(django_reverse('game:heroes:show', args=[account.id])),
+                           texts="")
 
     def test_update_description(self):
         logic.set_hero_description(self.hero.id, 'bla-bla')

--- a/src/the_tale/the_tale/game/heroes/tests/test_logic.py
+++ b/src/the_tale/the_tale/game/heroes/tests/test_logic.py
@@ -31,7 +31,7 @@ class HeroDescriptionTests(utils_testcase.TestCase):
         account.ban_game(days=1)
         self.assertTrue(account.is_ban_game)
         self.check_html_ok(self.request_html(django_reverse('game:heroes:show', args=[account.id])),
-                           texts="")
+                           texts="pgf-about-container")
 
     def test_update_description(self):
         logic.set_hero_description(self.hero.id, 'bla-bla')

--- a/src/the_tale/the_tale/game/heroes/tests/test_logic.py
+++ b/src/the_tale/the_tale/game/heroes/tests/test_logic.py
@@ -31,7 +31,7 @@ class HeroDescriptionTests(utils_testcase.TestCase):
         account.ban_game(days=1)
         self.assertTrue(account.is_ban_game)
         self.check_html_ok(self.request_html(django_reverse('game:heroes:show', args=[account.id])),
-                           texts="pgf-about-container")
+                           texts=["Хранитель пока ничего не рассказал о герое."])
 
     def test_update_description(self):
         logic.set_hero_description(self.hero.id, 'bla-bla')

--- a/src/the_tale/the_tale/game/heroes/tests/test_logic.py
+++ b/src/the_tale/the_tale/game/heroes/tests/test_logic.py
@@ -31,7 +31,7 @@ class HeroDescriptionTests(utils_testcase.TestCase):
         account.ban_game(days=1)
         self.assertTrue(account.is_ban_game)
         self.check_html_ok(self.request_html(django_reverse('game:heroes:show', args=[account.id])),
-                           texts=["Хранитель пока ничего не рассказал о герое."])
+                           texts=["test-no-hero-description-message"])
 
     def test_update_description(self):
         logic.set_hero_description(self.hero.id, 'bla-bla')

--- a/src/the_tale/the_tale/game/heroes/tests/test_logic.py
+++ b/src/the_tale/the_tale/game/heroes/tests/test_logic.py
@@ -20,18 +20,17 @@ class HeroDescriptionTests(utils_testcase.TestCase):
     def test_no_description(self):
         self.assertEqual(logic.get_hero_description(self.hero.id), '')
 
-    def test_banned_acc_hero_description(self):
-        logic.set_hero_description(self.hero.id, 'bla-bla')
-        self.assertFalse(account.is_ban_game)
-        with mock.patch('the_tale.game.workers.supervisor.Worker.cmd_sync_hero_required') as cmd_sync_hero_required:
-            account.ban_game(days=1)
-        self.assertEqual(cmd_sync_hero_required.call_count, 1)
-        self.assertTrue(account.is_ban_game)
-        self.assertEqual(logic.get_hero_description(self.hero.id), '')
-
     def test_has_description(self):
         logic.set_hero_description(self.hero.id, 'bla-bla')
         self.assertEqual(logic.get_hero_description(self.hero.id), 'bla-bla')
+
+    def test_banned_account_hero_description(self):
+        account = accounts_prototypes.AccountPrototype.get_by_id(self.hero.id)
+        logic.set_hero_description(self.hero.id, "bla-bla")
+        self.assertFalse(account.is_ban_game)
+        account.ban_game(days=1)
+        self.assertTrue(account.is_ban_game)
+        self.assertEqual(logic.get_hero_description(self.hero.id), '')
 
     def test_update_description(self):
         logic.set_hero_description(self.hero.id, 'bla-bla')


### PR DESCRIPTION
Добавил условие забанен ли игрок для get методов классов героя и учетной записи игрока.
Покрыл соответствующие изменения тестами.